### PR TITLE
Added support to remove a StealthPlugin evasion by type

### DIFF
--- a/PuppeteerExtraSharp/Plugins/ExtraStealth/StealthPlugin.cs
+++ b/PuppeteerExtraSharp/Plugins/ExtraStealth/StealthPlugin.cs
@@ -9,13 +9,17 @@ namespace PuppeteerExtraSharp.Plugins.ExtraStealth
     public class StealthPlugin : PuppeteerExtraPlugin
     {
         private readonly IPuppeteerExtraPluginOptions[] _options;
+        private readonly List<PuppeteerExtraPlugin> _standardEvasions;
 
         public StealthPlugin(params IPuppeteerExtraPluginOptions[] options) : base("stealth")
         {
             _options = options;
+            _standardEvasions = GetStandardEvasions();
         }
 
-        public override ICollection<PuppeteerExtraPlugin> GetDependencies() => new List<PuppeteerExtraPlugin>()
+        private List<PuppeteerExtraPlugin> GetStandardEvasions()
+        {
+            return new List<PuppeteerExtraPlugin>()
         {
             new WebDriver(),
             // new ChromeApp(),
@@ -34,6 +38,9 @@ namespace PuppeteerExtraSharp.Plugins.ExtraStealth
             new ContentWindow(),
             new SourceUrl()
         };
+        }
+
+        public override ICollection<PuppeteerExtraPlugin> GetDependencies() => _standardEvasions;
 
         public override async Task OnPageCreated(Page page)
         {
@@ -44,6 +51,11 @@ namespace PuppeteerExtraSharp.Plugins.ExtraStealth
         private T GetOptionByType<T>() where T : IPuppeteerExtraPluginOptions
         {
             return _options.OfType<T>().FirstOrDefault();
+        }
+
+        public void RemoveEvasionByType<T>() where T : PuppeteerExtraPlugin
+        {
+            _standardEvasions.RemoveAll(ev => ev is T);
         }
     }
 }

--- a/PuppeteerExtraSharp/Plugins/ExtraStealth/readme.md
+++ b/PuppeteerExtraSharp/Plugins/ExtraStealth/readme.md
@@ -48,3 +48,13 @@ var webGLVendor = "Intel Inc."; // your custom webGL vendor
 var render = "Intel Iris OpenGL Engine"; // your custom webGL renderer
 var languagesSettings = new StealthWebGLOptions(webGLVendor, render);
 ```
+
+# Removing evasions:
+You can remove an evasion from the plugin by using the RemoveEvasionByType
+```c#
+var extra = new PuppeteerExtra();
+// initialize stealth plugin
+var stealth = new StealthPlugin();
+stealthPlugin.RemoveEvasionByType<ContentWindow>();
+var browser = await extra.Use(stealth).LaunchAsync(new LaunchOptions());
+```


### PR DESCRIPTION
Proposed solution to #29 - the need to remove certain evasions from the StealthPlugin (the content window evasion was causing problems for me)

I added a method to the StealthPlugin - RemoveEvasionByType<T>() to remove an evasion. Had to change the initialization of the evasions list so that the list of standard evasions is populated in the constructor. Then the expressionbody for GetDependencies is returning this private list.

I was unable to get the test project to build due to some missing keys on the Captcha stuff, but I have manually tested the solution and it works for me at least.

I hope it's useful, and thank you for creating this package.

